### PR TITLE
Use https for MathJax to avoid broken math lemma

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -24,7 +24,7 @@
 
     <link rel="shortcut icon" href="/favicon.ico" />
 
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" />
+    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" />
 
     $imports$
 


### PR DESCRIPTION
First of all, thank you so much for the great post of [`Lazy Dynamic Programming`](https://jelv.is/blog/Lazy-Dynamic-Programming/).

While reading the post, I just noticed the **math** syntax are broken in the page like following

<img width="767" alt="image" src="https://user-images.githubusercontent.com/6782666/94909077-96401e00-04dd-11eb-851d-6274831423af.png">

and DevTools says the `mathjax` script is not loaded because of mixed content

<img width="744" alt="image" src="https://user-images.githubusercontent.com/6782666/94909105-a35d0d00-04dd-11eb-8263-1698b65135c2.png">

so, I think moving the script from `http` to `https` should be able to fix the issue!
